### PR TITLE
Make all spaces underscores in CSV filename generation

### DIFF
--- a/client/app/pages/queries/query-results-link.js
+++ b/client/app/pages/queries/query-results-link.js
@@ -23,7 +23,7 @@ function queryResultLink(Auth) {
           element.attr('href', '');
         } else {
           element.attr('href', `api/queries/${scope.query.id}/results/${scope.queryResult.getId()}.${fileType}${resultLinkQueryParams(scope)}`);
-          element.attr('download', `${scope.query.name.replace(' ', '_') + moment(scope.queryResult.getUpdatedAt()).format('_YYYY_MM_DD')}.${fileType}`);
+          element.attr('download', `${scope.query.name.replace(/ /g, '_') + moment(scope.queryResult.getUpdatedAt()).format('_YYYY_MM_DD')}.${fileType}`);
         }
       });
     },


### PR DESCRIPTION
Right now, the code only replaces the first space in the query name with underscores when generating a filename.

JavaScript's string `replace` method only replaces the first occurrence if you give a string as the first argument. The regular expresion `/ /g` will match all occurrences of the character (space) as desired.