### PR TITLE
Inactivity warnings using ng-idle

### DIFF
--- a/client/app/index.js
+++ b/client/app/index.js
@@ -27,6 +27,7 @@ import 'angular-ui-ace';
 import 'angular-resizable';
 import ngGridster from 'angular-gridster';
 import { each } from 'underscore';
+import 'ng-idle';
 
 import './sortable';
 
@@ -49,7 +50,7 @@ const logger = debug('redash');
 
 const requirements = [
   ngRoute, ngResource, ngSanitize, uiBootstrap, ngMessages, uiSelect, 'angularMoment', toastr, 'ui.ace',
-  ngUpload, 'angularResizable', vsRepeat, 'ui.sortable', ngGridster.name,
+  ngUpload, 'angularResizable', vsRepeat, 'ui.sortable', ngGridster.name, 'ngIdle',
 ];
 
 const ngModule = angular.module('app', requirements);

--- a/client/app/utils/api.js
+++ b/client/app/utils/api.js
@@ -15,7 +15,7 @@ function httpPrefixInterceptor($q) {
       }
 
       // If there is no reference to a service, prepend the redash root
-      const EXTERNAL_SERVICES = ['zenodot'];
+      const EXTERNAL_SERVICES = ['zenodot', 'admissions'];
       let root;
       if (url[0] === '/') {
         root = url.slice(1).split('/')[0];

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "plotly.js": "1.26.1",
     "ui-select": "^0.19.6",
     "underscore": "^1.8.3",
-    "underscore.string": "^3.3.4"
+    "underscore.string": "^3.3.4",
+    "ng-idle": "^1.3.2"
   },
   "devDependencies": {
     "babel-core": "^6.18.0",


### PR DESCRIPTION
This adds inactivity warnings to redash so that the user is made aware of when their session is about to time out. Also takes advantage of the `keepalive` API to ensure the session is kept alive while the user is active.