### PR TITLE
Editor configs

### DIFF
--- a/client/app/assets/css/capdash.css
+++ b/client/app/assets/css/capdash.css
@@ -1,0 +1,7 @@
+.ace_editor.ace_autocomplete {
+    width: 650px !important;
+}
+
+.editor-config-checkbox {
+    display: inline;
+}

--- a/client/app/index.js
+++ b/client/app/index.js
@@ -35,6 +35,9 @@ import './assets/css/superflat_redash.css';
 import './assets/css/redash.css';
 import './assets/css/main.scss';
 
+// Custom css
+import './assets/css/capdash.css';
+
 import * as pages from './pages';
 import * as components from './components';
 import * as filters from './filters';

--- a/client/app/pages/queries/query-editor.js
+++ b/client/app/pages/queries/query-editor.js
@@ -3,6 +3,7 @@ import 'brace/mode/python';
 import 'brace/mode/sql';
 import 'brace/mode/json';
 import 'brace/ext/language_tools';
+import 'brace/keybinding/vim';
 import { map } from 'underscore';
 
 // By default Ace will try to load snippet files for the different modes and fail.
@@ -25,6 +26,7 @@ function queryEditor(QuerySnippet) {
       query: '=',
       schema: '=',
       syntax: '=',
+      customEditorConfigs: '=',
     },
     template: '<div ui-ace="editorOptions" ng-model="query.query"></div>',
     link: {
@@ -38,7 +40,7 @@ function queryEditor(QuerySnippet) {
             behavioursEnabled: true,
             enableSnippets: true,
             enableBasicAutocompletion: true,
-            enableLiveAutocompletion: true,
+            enableLiveAutocompletion: $scope.customEditorConfigs.liveAutocompletion,
             autoScrollEditorIntoView: true,
           },
           onLoad(editor) {
@@ -77,11 +79,25 @@ function queryEditor(QuerySnippet) {
                 // If there are too many tokens we disable live autocomplete,
                 // as it makes typing slower.
                 if (tokensCount > 5000) {
-                  editor.setOption('enableLiveAutocompletion', false);
+                  editor.setOption({ enableLiveAutocompletion: false });
                 } else {
-                  editor.setOption('enableLiveAutocompletion', true);
+                  editor.setOption({
+                    enableLiveAutocompletion: $scope.customEditorConfigs.liveAutocompletion,
+                  });
                 }
               }
+            });
+
+            $scope.$watch('customEditorConfigs.vimMode', (vimMode) => {
+              if (vimMode) {
+                editor.setKeyboardHandler('ace/keyboard/vim');
+              } else {
+                editor.setKeyboardHandler();
+              }
+            });
+
+            $scope.$watch('customEditorConfigs.liveAutocompletion', (liveAutocompletion) => {
+              editor.setOptions({ enableLiveAutocompletion: liveAutocompletion });
             });
 
             $scope.$parent.$on('angular-resizable.resizing', () => {

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -103,6 +103,25 @@
               <select ng-disabled="!isQueryOwner" ng-model="query.data_source_id" ng-change="updateDataSource()"
                       ng-options="ds.id as ds.name for ds in dataSources"></select>
 
+              <!-- CAPTRICITY CUSTOMIZATION -->
+              <div class="editor-config-checkbox form-check form-check-inline">
+                <label class="form-check-label">
+                  <input class="form-check-input"
+                         type="checkbox"
+                         id="editor-vim-mode"
+                         ng-model="customEditorConfigs.vimMode"> Vim Mode
+                </label>
+              </div>
+              <div class="editor-config-checkbox form-check form-check-inline">
+                <label class="form-check-label">
+                  <input class="form-check-input"
+                         type="checkbox"
+                         id="editor-live-autocomplete"
+                         ng-model="customEditorConfigs.liveAutocompletion"> Live Autocompletion
+                </label>
+              </div>
+              <!-- END CAPTRICITY CUSTOMIZATION -->
+
               <div class="pull-right">
                 <button class="btn btn-s btn-default" ng-click="togglePublished()" ng-if="query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
                   <span class="fa fa-paper-plane"></span> Publish
@@ -131,7 +150,8 @@
             <p style="height:calc(100% - 40px);">
               <query-editor query="query"
                             schema="schema"
-                            syntax="dataSource.syntax"></query-editor>
+                            syntax="dataSource.syntax"
+                            custom-editor-configs="customEditorConfigs"></query-editor>
             </p>
         </div>
       </div>

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -118,6 +118,11 @@ function QueryViewCtrl($scope, Events, CapsDatasets, $route, $routeParams, $loca
   $scope.query = $route.current.locals.query;
   $scope.showPermissionsControl = clientConfig.showPermissionsControl;
 
+  $scope.customEditorConfigs = {
+    vimMode: false,
+    liveAutocompletion: true,
+  };
+
   const shortcuts = {
     'mod+enter': $scope.executeQuery,
   };

--- a/client/app/pages/query-snippets/edit.html
+++ b/client/app/pages/query-snippets/edit.html
@@ -14,6 +14,19 @@
       <div class="form-group">
         <label>Snippet</label>
         <pre ng-if="!$ctrl.canEdit">{{$ctrl.snippet.snippet}}</pre>
+        <div ng-if="$ctrl.canEdit">
+          <!-- CAPTRICITY CUSTOMIZATION -->
+          <div class="editor-config-checkbox form-check form-check-inline">
+            <label class="form-check-label">
+              <input class="form-check-input"
+                     type="checkbox"
+                     id="editor-vim-mode"
+                     ng-model="$ctrl.customEditorConfigs.vimMode"
+                     ng-change="toggleVimMode($ctrl.customEditorConfigs.vimMode)"> Vim Mode
+            </label>
+          </div>
+          <!-- END CAPTRICITY CUSTOMIZATION -->
+        </div>
         <div ui-ace="$ctrl.editorOptions" ng-model="$ctrl.snippet.snippet" style="height:300px" ng-if="$ctrl.canEdit"></div>
       </div>
 

--- a/client/app/pages/query-snippets/edit.js
+++ b/client/app/pages/query-snippets/edit.js
@@ -1,9 +1,14 @@
 import 'brace/mode/snippets';
 import template from './edit.html';
 
-function SnippetCtrl($routeParams, $http, $location, toastr, currentUser, Events, QuerySnippet) {
+function SnippetCtrl(
+    $scope, $routeParams, $http, $location, toastr, currentUser, Events, QuerySnippet) {
   this.snippetId = $routeParams.snippetId;
   Events.record('view', 'query_snippet', this.snippetId);
+
+  this.customEditorConfigs = {
+    vimMode: false,
+  };
 
   this.editorOptions = {
     mode: 'snippets',
@@ -16,6 +21,14 @@ function SnippetCtrl($routeParams, $http, $location, toastr, currentUser, Events
       editor.$blockScrolling = Infinity;
       editor.getSession().setUseWrapMode(true);
       editor.setShowPrintMargin(false);
+
+      $scope.toggleVimMode = (vimMode) => {
+        if (vimMode) {
+          editor.setKeyboardHandler('ace/keyboard/vim');
+        } else {
+          editor.setKeyboardHandler();
+        }
+      };
     },
   };
 


### PR DESCRIPTION
cc @rameshvs 

This adds controls to turn on/off the following two options in the query editor:
- Vim bindings
- Live autocompletion (autocompletion as you type)

Also adds CSS styles to extend the autocompletion window.