### PR TITLE
Add vim commands

### DIFF
--- a/client/app/pages/queries/query-editor.js
+++ b/client/app/pages/queries/query-editor.js
@@ -27,6 +27,8 @@ function queryEditor(QuerySnippet) {
       schema: '=',
       syntax: '=',
       customEditorConfigs: '=',
+      saveQuery: '&',
+      executeQuery: '&',
     },
     template: '<div ui-ace="editorOptions" ng-model="query.query"></div>',
     link: {
@@ -144,6 +146,18 @@ function queryEditor(QuerySnippet) {
 
         window.ace.acequire(['ace/ext/language_tools'], (langTools) => {
           langTools.addCompleter(schemaCompleter);
+        });
+
+        const saveQuery = $scope.saveQuery();
+        const executeQuery = $scope.executeQuery();
+        window.ace.config.loadModule('ace/keyboard/vim', (module) => {
+          const VimApi = module.CodeMirror.Vim;
+          VimApi.defineEx('write', 'w', () => {
+            saveQuery();
+          });
+          VimApi.defineEx('run', 'r', () => {
+            executeQuery();
+          });
         });
       },
     },

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -151,6 +151,8 @@
               <query-editor query="query"
                             schema="schema"
                             syntax="dataSource.syntax"
+                            save-query="saveQuery"
+                            execute-query="executeQuery"
                             custom-editor-configs="customEditorConfigs"></query-editor>
             </p>
         </div>


### PR DESCRIPTION
Note: could not do `:execute` for `:r` as `ace` has a restriction where the shorthand must be the first char of the longhand.